### PR TITLE
clx backend: windows fix

### DIFF
--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -71,6 +71,9 @@
 	    :protocol protocol))))
 
 (defun helpfully-automagic-clx-server-path ()
+  #+win32
+  (parse-clx-server-path '(:clx :host "localhost" :protocol :internet))
+  #-win32
   (restart-case (automagic-clx-server-path)
     (use-localhost ()
       :report "Use local unix display"


### PR DESCRIPTION
clx backend works in Windows when using host "localhost" and protocol "internet"